### PR TITLE
DB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 |Column|Type|Options|
 |------|----|-------|
 |name|string|null: false, index:true|
-|eamil|string|null: false|
 
 ### Association
 - has_many :groups_users

--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@
 
 ### Association
 - belongs_to :user
-- belongs_to :user
+- belongs_to :group


### PR DESCRIPTION
#What
emailカラムの削除、belongs_to :groupへの置き換え

#Why
emailカラムはdeviseで生成されるため、belongs_to :userが重複しているため
