### PR TITLE
グループ作成サイドバー表示

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,18 +1,36 @@
 class GroupsController < ApplicationController
+
+  def index
+
+  end
+
+
   def new
     @group = Group.new
+    @group.users << current_user
   end
 
   def edit
-   @group = Group.find(params[:id])
+    
   end
 
   def create
+    @group = Group.new(group_params)
+    if @group.save
+      redirect_to root_path, notice: "グループを作成しました"
+    else
+      render :new
+    end
   end
 
   def update
   end
+
   
+  private
+  def group_params
+    params.require(:group).permit(:name, { :user_ids => [] })
+  end
   
     
   

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -27,3 +27,4 @@
       .chat-group-form__field--left
       .chat-group-form__field--right
         %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "更新する"}/
+    = render "layouts/flash"

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,0 +1,3 @@
+.wrapper
+
+  = render "shared/content-side"

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,30 +1,29 @@
 .chat-group-form
   %h1 新規チャットグループ
-  %form#new_chat_gorup.new_chat_group{"accept-charset":"UTF-8", action: "/chat_groups", method: "post"}
-    %input{name: "utf8", type: "hidden", value: "✔︎"}/
-    %input{name: "authenticity_token", type: "hidden", value: "AxFKlYEhD6eqX1PiZoTYQDANtKvgcFSXZQXHt5hyTl55/U/CHC5rtPavrcu2za65riz4tekZEy56vP6kEb2wYA=="}
+  = form_for @group do |f|
+    - if @group.errors.any?
+      .chat-group-form__errors
+        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました"
+        %ul
+          - @group.errors.full_messages.each do |message|
+            %li= message
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
+        = f.label :name, class: "chat-group-form__label"
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+        = f.text_field :name, class: "chat__group_name chat-group-form__input", placeholder: "グループ名を入力してください"
     .chat-group-form__field.clearfix
       / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_チャットメンバー追加"} チャットメンバーを追加
+        = f.label "チャットメンバー", class: "chat-group-form__label"
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "追加したいユーザー名を入力してください", type: "text"}/
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
-      .chat-group-form__field--right
-        = form_for @group do |f|
-          = f.collection_check_boxes(:user_ids, User.all, :id, :name) do |b|
-            = b.label { b.check_box + b.text }
+        = f.collection_check_boxes :user_ids, User.all, :id, :name
+    
         / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
         / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
     .chat-group-form__field
       .chat-group-form__field--left
       .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "更新する"}/
+        = f.submit class: "chat-group-form__action-btn"
+

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,23 +1,5 @@
 .wrapper
-  .content-side
-    .left-header
-      .left-header__box
-        .left-header__box__user-name
-          = current_user.name
-        %ul.left-header__box__menu
-          %li.left-header__box__menu__group-new
-            =link_to new_group_path, class: "left-header__box__menu__group-new__btn left-header__box__menu__group-new__btn--edit" do
-              = fa_icon "pencil-square-o", class: "post-icon"
-          %li.left-heaser__box__menu__user-edit
-            =link_to edit_user_path(current_user), class: "left-header__box__menu__user-edit__btn left-header__box__menu__user-edit__btn--cog" do
-              = fa_icon "cog", class: "post-icon"
-            
-    .groups
-      .groups__group
-        .groups__group__group-name
-          test-group
-        .groups__group__message
-          test
+  = render "shared/content-side"
 
   .content
     .right-header

--- a/app/views/shared/_content-side.html.haml
+++ b/app/views/shared/_content-side.html.haml
@@ -1,0 +1,21 @@
+.content-side
+  .left-header
+    .left-header__box
+      .left-header__box__user-name
+        = current_user.name
+      %ul.left-header__box__menu
+        %li.left-header__box__menu__group-new
+          =link_to new_group_path, class: "left-header__box__menu__group-new__btn left-header__box__menu__group-new__btn--edit" do
+            = fa_icon "pencil-square-o", class: "post-icon"
+        %li.left-heaser__box__menu__user-edit
+          =link_to edit_user_path(current_user), class: "left-header__box__menu__user-edit__btn left-header__box__menu__user-edit__btn--cog" do
+            = fa_icon "cog", class: "post-icon"
+            
+  .groups
+    .groups__group
+      - current_user.groups.each do |group|
+        = link_to "#" do
+          .groups__group__group-name
+            = group.name
+          .groups__group__message
+            メッセージはまだありません。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root "messages#index"
   resources :users, only: [:edit, :update]
-  resources :groups, only: [:new, :create, :update, :edit] 
+  resources :groups, only: [:new, :create, :update, :edit, :index] 
     
 end


### PR DESCRIPTION
＃What
 グループ作成機能実装、作成したグループをサイドバーに表示

＃Why
グループを作成する画面で、該当のグループに追加するユーザーを選択し、
フラッシュメッセージを出し、グループの名前にはバリデーションをかけ、
自身が所属するグループをサイドバーに表示するため