### PR TITLE
グループ編集機能

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -11,7 +11,7 @@ class GroupsController < ApplicationController
   end
 
   def edit
-    
+    @group = Group.new
   end
 
   def create

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,22 +1,21 @@
 .chat-group-form
   %h1 チャットグループ編集
-  %form#edit_chat_group_22.edit_chat_group{"accept-charset" => "UTF-8", :action => "/chat_group/22", :method => "post"}
-    
+  = form_for @group do |f|
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
+        = f.label :name, class: "chat-group-form__label"
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text", value: "hoge"}/
+        = f.text_field :name, class: "chat__group_name", placeholder: "グループ名を入力してください"
     .chat-group-form__field.clearfix
       / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_"} チャットメンバーを追加
+        = f.label :name, class: "chat-group-form__label"
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "追加したいユーザーを入力してください", type: "text", value: "hoge"}/
+        = f.text_field :name, class: "chat__group_name", placeholder: " 追加したいユーザーを入力してください"
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
+        = f.label_field :name, class: "chat-group-form__label"
       .chat-group-form__field
         = form_for @group do |f|
           = f.collection_check_boxes(:user_ids, User.all, :id, :name) do |b|
@@ -28,3 +27,6 @@
       .chat-group-form__field--right
         %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "更新する"}/
     = render "layouts/flash"
+
+
+   

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,3 +1,3 @@
 .wrapper
-
   = render "shared/content-side"
+  = render "shared/content"

--- a/app/views/shared/_content.html.haml
+++ b/app/views/shared/_content.html.haml
@@ -1,0 +1,31 @@
+.content
+  .right-header
+    .right-header__box
+      .right-header__box__now-group
+        test-group
+      .right-header__box__people
+        aaa
+      = link_to "Edit", edit_group_path(current_user), class: "right-header__btn--edit"
+        
+                
+  .messages
+    .messages__message
+      .messages__message__post
+        .messages__message__post__poster
+          aaa
+        .messages__message__post__date
+          2019/09/07 16:59:01
+    .messages__message__text
+      aaaa
+        
+
+  .form
+    %form.new-message
+      .input-box
+        %input.input-box__text{name: "message", placeholder: "type a message", type: "text", width: "100"}
+        %label.upload-label{for: "message_image"}
+          %span
+            %i.fa.fa-picture-o
+          %input.upload-label__file{type: "file", name: "message[image]", id: "message_image"}
+      %input.submit-btn{name: "commit", value: "Send", type: "submit"}
+                

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  root "messages#index"
+  root "groups#index"
   resources :users, only: [:edit, :update]
   resources :groups, only: [:new, :create, :update, :edit, :index] 
     


### PR DESCRIPTION
＃What
グループ編集機能を実装、ルートパスを変更
＃Why
サイドバーのグループのリストを動的に変更、グループの作成と編集画面のフォームを共通化のため
ルートパスは、チャット画面のビューを作成する際、仮に設定したmessages#indexのままとなっているから